### PR TITLE
Add Submission Forms for Speaker Proposals in Community Meet-ups (#2) and more

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,46 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/site"
+  cmd = "go build -o ./tmp/site ./cmd/site"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 PORT=:3000
-ENV=env
+ENV=dev
 
 PSQL_DSN="host=localhost port=5432 user=go-insider password=password dbname=db sslmode=disable"
 PSQL_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+PORT=:3000
+ENV=env
+
+PSQL_DSN="host=localhost port=5432 user=go-insider password=password dbname=db sslmode=disable"
+PSQL_HOST=localhost
+PSQL_PORT=5432
+PSQL_USER=go-insider
+PSQL_PASSWORD=site-password
+PSQL_DATABASE=db
+PSQL_SSLMODE=disable
+MAX_OPEN_CONNS=25
+MAX_IDLE_CONNS=25
+MAX_IDLE_TIME=15m
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.encore
+tmp/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,13 @@ COPY go.mod  ./
 RUN go mod download
 
 # Copy the source code into the container
-COPY cmd/ ./cmd/
-COPY public/ ./public/
+COPY . .
 
 # Build the application
-RUN go build -o /myapp cmd/site/main.go
+RUN go build -o /site ./cmd/site/
 
 # Expose port 3000
 EXPOSE 3000
 
 # Run the binary program
-CMD ["/myapp"]
+CMD ["/site"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+help:
+	@echo "Available commands:"
+	@echo "  make up          : Start the database and web server"
+	@echo "  make build       : Build Docker images"
+	@echo "  make down        : Stop and remove Docker containers"
+	@echo "  make db/migrate  : Run database migrations"
+	@echo "  make db/psql     : Connect to PostgreSQL with psql"
+	@echo "  make db/logs     : View Docker compose logs"
+	@echo "  make help        : Show this help message"
+
+up:
+	@echo "starting db..."
+	@docker compose up -d
+	@sleep 1
+	@echo "making migrations..."
+	@goose -dir="./migrations" postgres "host=localhost port=5432 user=go-insider password=site-password dbname=db sslmode=disable" up
+	@echo "starting web server..."
+	@air
+
+build:
+	docker compose build
+
+down:
+	docker compose down --remove-orphans
+
+db/migrate:
+	goose -dir="./migrations" postgres "host=localhost port=5432 user=go-insider password=password dbname=db sslmode=disable" up
+
+db/psql:
+	psql "--host=localhost" "--port=5432" "--dbname=db" "--user=go-insider" "--set=sslmode=disable"
+
+db/logs:
+	docker compose logs

--- a/README.md
+++ b/README.md
@@ -2,4 +2,25 @@
 
 [![Fly Deploy Site](https://github.com/Golang-Insiders/site/actions/workflows/deploy_site.yaml/badge.svg?branch=main)](https://github.com/Golang-Insiders/site/actions/workflows/deploy_site.yaml)
 
+## Getting started
+### Requirements
+- [Docker](https://www.docker.com/)
+- [Docker Compose](https://docs.docker.com/compose/)
+- [air](https://github.com/cosmtrek/air)
+- [goose](https://github.com/pressly/goose)
 
+### Running
+Copy .env.example to .env
+```sh
+cp .env.example .env
+```
+
+Using make
+```sh
+make up
+```
+
+Show available commands
+```sh
+make help
+```

--- a/cmd/site/config.go
+++ b/cmd/site/config.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/golang-insiders/site/internal/data"
 	"github.com/joho/godotenv"
+)
+
+var (
+	DEFAULT_PORT = ":3000"
+	DEFAULT_ENV  = "dev"
 )
 
 type config struct {
@@ -21,11 +27,17 @@ func loadConfig() (config, error) {
 	}
 
 	cfg.port = os.Getenv("PORT")
+	if cfg.port == "" {
+		cfg.port = DEFAULT_PORT
+	}
 	cfg.env = os.Getenv("ENV")
+	if cfg.env == "" {
+		cfg.env = DEFAULT_ENV
+	}
 
 	cfg.db, err = data.LoadDBConfig()
 	if err != nil {
-		return cfg, err
+		return cfg, fmt.Errorf("Failed to load DB config: %v", err)
 	}
 
 	return cfg, nil

--- a/cmd/site/config.go
+++ b/cmd/site/config.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+
+	"github.com/golang-insiders/site/internal/data"
+	"github.com/joho/godotenv"
+)
+
+type config struct {
+	port string
+	env  string
+	db   data.PostgresConfig
+}
+
+func loadConfig() (config, error) {
+	var cfg config
+	err := godotenv.Load()
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.port = os.Getenv("PORT")
+	cfg.env = os.Getenv("ENV")
+
+	cfg.db, err = data.LoadDBConfig()
+	if err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}

--- a/cmd/site/handlers.go
+++ b/cmd/site/handlers.go
@@ -52,13 +52,13 @@ func (app *application) handleTalkPost(w http.ResponseWriter, r *http.Request) {
 		Timezone:        tz,
 	}
 
-	ok, msg := talk.ValidateTalk()
-	if !ok {
-		fmt.Fprintf(w, "%s", msg)
+	err := types.ValidateTalk(talk)
+	if err != nil {
+		fmt.Fprintf(w, "%s", err.Error())
 		return
 	}
 
-	err := app.services.Talks.Insert(ctx, &talk)
+	err = app.services.Talks.Insert(ctx, &talk)
 	if err != nil {
 		log.Println("Error inserting data", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/cmd/site/handlers.go
+++ b/cmd/site/handlers.go
@@ -54,7 +54,11 @@ func (app *application) handleTalkPost(w http.ResponseWriter, r *http.Request) {
 
 	err := types.ValidateTalk(talk)
 	if err != nil {
-		fmt.Fprintf(w, "%s", err.Error())
+		templateData := newTemplateData()
+		templateData.TimeZones = app.services.TimeZone.LoadTimeZones("")
+		templateData.Errors = append(templateData.Errors, err.Error())
+
+		app.tmpl.render(w, "new-talk", templateData)
 		return
 	}
 

--- a/cmd/site/handlers.go
+++ b/cmd/site/handlers.go
@@ -52,17 +52,19 @@ func (app *application) handleTalkPost(w http.ResponseWriter, r *http.Request) {
 		Timezone:        tz,
 	}
 
-	err := types.ValidateTalk(talk)
-	if err != nil {
+	errs := types.ValidateTalk(talk)
+	if errs != nil {
 		templateData := newTemplateData()
 		templateData.TimeZones = app.services.TimeZone.LoadTimeZones("")
-		templateData.Errors = append(templateData.Errors, err.Error())
+		for _, e := range errs {
+			templateData.Errors = append(templateData.Errors, e.Error())
+		}
 
 		app.tmpl.render(w, "new-talk", templateData)
 		return
 	}
 
-	err = app.services.Talks.Insert(ctx, &talk)
+	err := app.services.Talks.Insert(ctx, &talk)
 	if err != nil {
 		log.Println("Error inserting data", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/cmd/site/handlers.go
+++ b/cmd/site/handlers.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/golang-insiders/site/internal/data"
+	"github.com/golang-insiders/site/internal/types"
+)
+
+func (app *application) handleHome(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		fmt.Fprint(w, "Only accepts get requests")
+		return
+	}
+	app.tmpl.render(w, "index", nil)
+}
+
+func (app *application) handleTalkForm(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		fmt.Fprint(w, "Only accepts get requests")
+		return
+	}
+	templateData := newTemplateData()
+	templateData.TimeZones = data.LoadTimeZones("")
+	app.tmpl.render(w, "new-talk", templateData)
+}
+
+func (app *application) handleTalkPost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		fmt.Fprint(w, "Only accepts post requests")
+		return
+	}
+	username := r.PostFormValue("twitter-username")
+	title := r.PostFormValue("title")
+	summary := r.PostFormValue("summary")
+	tz := r.PostFormValue("time-zone")
+	talk := types.Talk{
+		TwitterUsername: username,
+		Title:           title,
+		Summary:         summary,
+		Timezone:        tz,
+	}
+	ok, msg := talk.ValidateTalk()
+	if !ok {
+		fmt.Fprintf(w, "%s", msg)
+		return
+	}
+	err := app.services.Talks.Insert(&talk)
+	if err != nil {
+		log.Println("Error inserting data", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "Error inserting data")
+	}
+	redirectUrl := fmt.Sprintf("/talk?id=%d", talk.ID)
+	http.Redirect(w, r, redirectUrl, http.StatusFound)
+}
+
+func (app *application) handleGetTalkByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		fmt.Fprint(w, "Only accepts get requests")
+		return
+	}
+	idStr := r.URL.Query().Get("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		fmt.Fprint(w, "ID must be an int")
+		return
+	}
+	t, err := app.services.Talks.GetByID(id)
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrRecordNotFound):
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, "Talk not found")
+		default:
+			log.Println(err)
+			fmt.Fprintf(w, "Error getting talk")
+		}
+		return
+	}
+	templateData := newTemplateData()
+	templateData.Talk = t
+	app.tmpl.render(w, "talk-id", templateData)
+}

--- a/cmd/site/handlers.go
+++ b/cmd/site/handlers.go
@@ -25,7 +25,7 @@ func (app *application) handleTalkForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	templateData := newTemplateData()
-	templateData.TimeZones = data.LoadTimeZones("")
+	templateData.TimeZones = app.services.TimeZone.LoadTimeZones("")
 	app.tmpl.render(w, "new-talk", templateData)
 }
 

--- a/cmd/site/main.go
+++ b/cmd/site/main.go
@@ -16,7 +16,7 @@ type application struct {
 func main() {
 	cfg, err := loadConfig()
 	if err != nil {
-		log.Fatal("Couldn't load env variables")
+		log.Fatal("Couldn't load config")
 	}
 
 	db, err := data.OpenDB(cfg.db)
@@ -25,7 +25,10 @@ func main() {
 	}
 	defer db.Close()
 
-	services := data.NewServices(db)
+	services, err := data.NewServices(db)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	app := application{
 		tmpl:     newTemplate(),

--- a/cmd/site/templates.go
+++ b/cmd/site/templates.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"html/template"
+	"io"
+
+	"github.com/golang-insiders/site/internal/types"
+)
+
+type Templates struct {
+	templates *template.Template
+}
+
+func newTemplate() Templates {
+	return Templates{
+		templates: template.Must(template.ParseGlob("public/*.html")),
+	}
+}
+
+func (t *Templates) render(w io.Writer, name string, data *templateData) error {
+	return t.templates.ExecuteTemplate(w, name, data)
+}
+
+type templateData struct {
+	Talk      *types.Talk
+	TimeZones []string
+	Errors    []string
+}
+
+func newTemplateData() *templateData {
+	return &templateData{
+		Errors: nil,
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,18 +16,6 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
-  # web:
-  #   build:
-  #     context: ./
-  #     dockerfile: Dockerfile
-  #   restart: always
-  #   volumes:
-  #     - .env:/.env
-  #   ports:
-  #     - 3000:3000
-  #   networks:
-  #     - main
-
 networks:
   main:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+
+services:
+  db: 
+    image: postgres 
+    container_name: db
+    restart: always 
+    environment: 
+      POSTGRES_USER: ${PSQL_USER}
+      POSTGRES_PASSWORD: ${PSQL_PASSWORD}
+      POSTGRES_DB: ${PSQL_DATABASE}
+    ports:
+      - 5432:5432
+    networks:
+      - main
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  # web:
+  #   build:
+  #     context: ./
+  #     dockerfile: Dockerfile
+  #   restart: always
+  #   volumes:
+  #     - .env:/.env
+  #   ports:
+  #     - 3000:3000
+  #   networks:
+  #     - main
+
+networks:
+  main:
+
+volumes:
+  postgres_data:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/golang-insiders/site
 
 go 1.21
+
+require (
+	github.com/joho/godotenv v1.5.1
+	github.com/lib/pq v1.10.9
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/internal/data/database.go
+++ b/internal/data/database.go
@@ -1,0 +1,83 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+type PostgresConfig struct {
+	Host         string
+	Port         string
+	User         string
+	Password     string
+	Database     string
+	SSLMode      string
+	MaxOpenConns int
+	MaxIdleConns int
+	MaxIdleTime  string
+}
+
+func (cfg PostgresConfig) String() string {
+	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s", cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Database, cfg.SSLMode)
+}
+
+func OpenDB(cfg PostgresConfig) (*sql.DB, error) {
+	db, err := sql.Open("postgres", cfg.String())
+	if err != nil {
+		return nil, err
+	}
+
+	db.SetMaxOpenConns(cfg.MaxOpenConns)
+
+	db.SetMaxIdleConns(cfg.MaxIdleConns)
+
+	duration, err := time.ParseDuration(cfg.MaxIdleTime)
+	if err != nil {
+		return nil, err
+	}
+	db.SetConnMaxIdleTime(duration)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = db.PingContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+
+}
+
+func LoadDBConfig() (PostgresConfig, error) {
+	var cfg PostgresConfig
+
+	cfg.Host = os.Getenv("PSQL_HOST")
+	cfg.Port = os.Getenv("PSQL_PORT")
+	cfg.User = os.Getenv("PSQL_USER")
+	cfg.Password = os.Getenv("PSQL_PASSWORD")
+	cfg.Database = os.Getenv("PSQL_DATABASE")
+	cfg.SSLMode = os.Getenv("PSQL_SSLMODE")
+
+	maxOpenConns, err := strconv.Atoi(os.Getenv("MAX_OPEN_CONNS"))
+	if err != nil {
+		return cfg, fmt.Errorf("failed to convert MAX_OPEN_CONNS to integer: %v", err)
+	}
+	cfg.MaxOpenConns = maxOpenConns
+
+	maxIdleConns, err := strconv.Atoi(os.Getenv("MAX_IDLE_CONNS"))
+	if err != nil {
+		return cfg, fmt.Errorf("failed to convert MAX_IDLE_CONNS to integer: %v", err)
+	}
+	cfg.MaxIdleConns = maxIdleConns
+
+	cfg.MaxIdleTime = os.Getenv("MAX_IDLE_TIME")
+
+	return cfg, nil
+}

--- a/internal/data/services.go
+++ b/internal/data/services.go
@@ -1,0 +1,22 @@
+package data
+
+import (
+	"database/sql"
+	"errors"
+)
+
+var (
+	ErrRecordNotFound = errors.New("record not found")
+)
+
+type Services struct {
+	Talks    TalkService
+	TimeZone TimeZoneService
+}
+
+func NewServices(db *sql.DB) Services {
+	return Services{
+		Talks:    TalkService{DB: db},
+		TimeZone: TimeZoneService{},
+	}
+}

--- a/internal/data/services.go
+++ b/internal/data/services.go
@@ -3,6 +3,7 @@ package data
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 )
 
 var (
@@ -14,9 +15,12 @@ type Services struct {
 	TimeZone TimeZoneService
 }
 
-func NewServices(db *sql.DB) Services {
+func NewServices(db *sql.DB) (Services, error) {
+	if db == nil {
+		return Services{}, fmt.Errorf("DB does not exist")
+	}
 	return Services{
 		Talks:    TalkService{DB: db},
 		TimeZone: TimeZoneService{},
-	}
+	}, nil
 }

--- a/internal/data/talks.go
+++ b/internal/data/talks.go
@@ -1,0 +1,58 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/golang-insiders/site/internal/types"
+)
+
+type TalkService struct {
+	DB *sql.DB
+}
+
+func (tm *TalkService) Insert(t *types.Talk) error {
+	query := `
+		INSERT INTO talks (twitter_username, title, summary, timezone)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at`
+
+	args := []interface{}{t.TwitterUsername, t.Title, t.Summary, t.Timezone}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	return tm.DB.QueryRowContext(ctx, query, args...).Scan(&t.ID, &t.CreatedAt)
+}
+
+func (tm *TalkService) GetByID(id int) (*types.Talk, error) {
+	query := `
+		SELECT id, twitter_username, title, summary, timezone
+		FROM talks
+		WHERE id=$1;
+	`
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var t types.Talk
+
+	err := tm.DB.QueryRowContext(ctx, query, id).Scan(
+		&t.ID,
+		&t.TwitterUsername,
+		&t.Title,
+		&t.Summary,
+		&t.Timezone,
+	)
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return nil, ErrRecordNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return &t, nil
+}

--- a/internal/data/talks.go
+++ b/internal/data/talks.go
@@ -13,27 +13,27 @@ type TalkService struct {
 	DB *sql.DB
 }
 
-func (tm *TalkService) Insert(t *types.Talk) error {
+func (tm TalkService) Insert(ctx context.Context, t *types.Talk) error {
 	query := `
 		INSERT INTO talks (twitter_username, title, summary, timezone)
 		VALUES ($1, $2, $3, $4)
 		RETURNING id, created_at`
 
-	args := []interface{}{t.TwitterUsername, t.Title, t.Summary, t.Timezone}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	return tm.DB.QueryRowContext(ctx, query, args...).Scan(&t.ID, &t.CreatedAt)
+	return tm.DB.QueryRowContext(ctx, query,
+		t.TwitterUsername, t.Title, t.Summary, t.Timezone,
+	).Scan(&t.ID, &t.CreatedAt)
 }
 
-func (tm *TalkService) GetByID(id int) (*types.Talk, error) {
+func (tm TalkService) GetByID(ctx context.Context, id int) (*types.Talk, error) {
 	query := `
 		SELECT id, twitter_username, title, summary, timezone
 		FROM talks
 		WHERE id=$1;
 	`
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	var t types.Talk

--- a/internal/data/timezone.go
+++ b/internal/data/timezone.go
@@ -11,7 +11,7 @@ type TimeZoneService struct {
 }
 
 // Shameless copy from stack overflow https://stackoverflow.com/questions/40120056/get-a-list-of-valid-time-zones-in-go
-func (tz *TimeZoneService) LoadTimeZones(path string) []string {
+func (tz TimeZoneService) LoadTimeZones(path string) []string {
 	var timeZones []string
 	zoneDir := "/usr/share/zoneinfo/"
 	files, _ := os.ReadDir(zoneDir + path)

--- a/internal/data/timezone.go
+++ b/internal/data/timezone.go
@@ -1,0 +1,30 @@
+package data
+
+import (
+	"os"
+	"strings"
+)
+
+type TimeZoneService struct {
+	// time zone directory might be different for different systems
+	// timeZoneDir string
+}
+
+// Shameless copy from stack overflow https://stackoverflow.com/questions/40120056/get-a-list-of-valid-time-zones-in-go
+func (tz *TimeZoneService) LoadTimeZones(path string) []string {
+	var timeZones []string
+	zoneDir := "/usr/share/zoneinfo/"
+	files, _ := os.ReadDir(zoneDir + path)
+	for _, f := range files {
+		if f.Name() != strings.ToUpper(f.Name()[:1])+f.Name()[1:] {
+			continue
+		}
+		if f.IsDir() {
+			timeZones = append(timeZones, tz.LoadTimeZones(path+"/"+f.Name())...)
+			tz.LoadTimeZones(path + "/" + f.Name())
+		} else {
+			timeZones = append(timeZones, (path + "/" + f.Name())[1:])
+		}
+	}
+	return timeZones
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -28,18 +28,19 @@ type Talk struct {
 	CreatedAt       time.Time
 }
 
-func ValidateTalk(t Talk) error {
+func ValidateTalk(t Talk) []error {
+	var errors []error
 	if t.TwitterUsername == INVALID_TWITTER_USER {
-		return ErrTwitterUsernameDNE
+		errors = append(errors, ErrTwitterUsernameDNE)
 	}
 	if len(t.Title) < MAX_TITLE_LEN {
-		return ErrTitleLength
+		errors = append(errors, ErrTitleLength)
 	}
 	if len(t.Summary) < MAX_SUMMARY_LEN {
-		return ErrSummaryLength
+		errors = append(errors, ErrSummaryLength)
 	}
 	if t.Timezone == "" {
-		return ErrTimeZone
+		errors = append(errors, ErrTimeZone)
 	}
-	return nil
+	return errors
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,12 +1,22 @@
 package types
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 var (
 	// Placeholder until check for valid twitter user function is implemented
+	// TODO: implement twitter username check (api? scraping?)
 	INVALID_TWITTER_USER = "dne"
 	MAX_TITLE_LEN        = 30
 	MAX_SUMMARY_LEN      = 300
+
+	// Declare errors for talk validation
+	ErrTwitterUsernameDNE = errors.New("twitter username must exist")
+	ErrTitleLength        = errors.New("title must be at least 30 characters long")
+	ErrSummaryLength      = errors.New("summary must be at least 300 characters long")
+	ErrTimeZone           = errors.New("timezone must be provided")
 )
 
 type Talk struct {
@@ -18,15 +28,18 @@ type Talk struct {
 	CreatedAt       time.Time
 }
 
-func (tf *Talk) ValidateTalk() (bool, string) {
-	if tf.TwitterUsername == INVALID_TWITTER_USER {
-		return false, "Twitter username must exist"
+func ValidateTalk(t Talk) error {
+	if t.TwitterUsername == INVALID_TWITTER_USER {
+		return ErrTwitterUsernameDNE
 	}
-	if len(tf.Title) < MAX_TITLE_LEN {
-		return false, "Title must be at least 30 characters long"
+	if len(t.Title) < MAX_TITLE_LEN {
+		return ErrTitleLength
 	}
-	if len(tf.Summary) < MAX_SUMMARY_LEN {
-		return false, "Summary must be at least 300 characters long"
+	if len(t.Summary) < MAX_SUMMARY_LEN {
+		return ErrSummaryLength
 	}
-	return true, ""
+	if t.Timezone == "" {
+		return ErrTimeZone
+	}
+	return nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,25 @@
+package types
+
+import "time"
+
+type Talk struct {
+	TwitterUsername string
+	Title           string
+	Summary         string
+	Timezone        string
+	ID              int64
+	CreatedAt       time.Time
+}
+
+func (tf *Talk) ValidateTalk() (bool, string) {
+	if tf.TwitterUsername == "dne" {
+		return false, "Twitter username must exist"
+	}
+	if len(tf.Title) < 30 {
+		return false, "Title must be at least 30 characters long"
+	}
+	if len(tf.Summary) < 300 {
+		return false, "Summary must be at least 300 characters long"
+	}
+	return true, ""
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2,6 +2,13 @@ package types
 
 import "time"
 
+var (
+	// Placeholder until check for valid twitter user function is implemented
+	INVALID_TWITTER_USER = "dne"
+	MAX_TITLE_LEN        = 30
+	MAX_SUMMARY_LEN      = 300
+)
+
 type Talk struct {
 	TwitterUsername string
 	Title           string
@@ -12,13 +19,13 @@ type Talk struct {
 }
 
 func (tf *Talk) ValidateTalk() (bool, string) {
-	if tf.TwitterUsername == "dne" {
+	if tf.TwitterUsername == INVALID_TWITTER_USER {
 		return false, "Twitter username must exist"
 	}
-	if len(tf.Title) < 30 {
+	if len(tf.Title) < MAX_TITLE_LEN {
 		return false, "Title must be at least 30 characters long"
 	}
-	if len(tf.Summary) < 300 {
+	if len(tf.Summary) < MAX_SUMMARY_LEN {
 		return false, "Summary must be at least 300 characters long"
 	}
 	return true, ""

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -5,25 +5,13 @@ import (
 	"testing"
 )
 
-// Generated a string of the provided length
-func generateString(length int) string {
-	if length <= 0 {
-		return ""
-	}
-
-	pattern := "abc"
-	result := strings.Repeat(pattern, (length/len(pattern))+1)[:length]
-
-	return result
-}
-
 var (
 	ValidTwitterUsername   = "valid-twitter-username"
 	InvalidTwitterUsername = "dne"
-	ValidTitle             = generateString(30)
-	InvalidTitle           = generateString(29)
-	ValidSummary           = generateString(300)
-	InvalidSummary         = generateString(299)
+	ValidTitle             = strings.Repeat("a", 30)
+	InvalidTitle           = strings.Repeat("a", 29)
+	ValidSummary           = strings.Repeat("a", 300)
+	InvalidSummary         = strings.Repeat("a", 299)
 )
 
 func TestValidateTalk(t *testing.T) {
@@ -44,10 +32,8 @@ func TestValidateTalk(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error: ", err)
 	}
-	if err != nil {
-		if err != ErrTwitterUsernameDNE {
-			t.Error("expected twitter username error: ", err)
-		}
+	if err != ErrTwitterUsernameDNE {
+		t.Error("expected twitter username error: ", err)
 	}
 
 	// Test invalid title check
@@ -60,10 +46,8 @@ func TestValidateTalk(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error: ", err)
 	}
-	if err != nil {
-		if err != ErrTitleLength {
-			t.Error("expected title length error: ", err)
-		}
+	if err != ErrTitleLength {
+		t.Error("expected title length error: ", err)
 	}
 
 	// Test invalid summary check
@@ -76,10 +60,8 @@ func TestValidateTalk(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error: ", err)
 	}
-	if err != nil {
-		if err != ErrSummaryLength {
-			t.Error("expected summary length error: ", err)
-		}
+	if err != ErrSummaryLength {
+		t.Error("expected summary length error: ", err)
 	}
 
 	// Test valid talk check

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,0 +1,95 @@
+package types
+
+import (
+	"strings"
+	"testing"
+)
+
+// Generated a string of the provided length
+func generateString(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
+	pattern := "abc"
+	result := strings.Repeat(pattern, (length/len(pattern))+1)[:length]
+
+	return result
+}
+
+var (
+	ValidTwitterUsername   = "valid-twitter-username"
+	InvalidTwitterUsername = "dne"
+	ValidTitle             = generateString(30)
+	InvalidTitle           = generateString(29)
+	ValidSummary           = generateString(300)
+	InvalidSummary         = generateString(299)
+)
+
+func TestValidateTalk(t *testing.T) {
+
+	// Test empty talk
+	err := ValidateTalk(Talk{})
+	if err == nil {
+		t.Error("expected an error")
+	}
+
+	// Test invalid twitter username check
+	err = ValidateTalk(Talk{
+		TwitterUsername: InvalidTwitterUsername,
+		Title:           ValidTitle,
+		Summary:         ValidSummary,
+		Timezone:        "UTC",
+	})
+	if err == nil {
+		t.Error("expected an error: ", err)
+	}
+	if err != nil {
+		if err != ErrTwitterUsernameDNE {
+			t.Error("expected twitter username error: ", err)
+		}
+	}
+
+	// Test invalid title check
+	err = ValidateTalk(Talk{
+		TwitterUsername: ValidTwitterUsername,
+		Title:           InvalidTitle,
+		Summary:         ValidSummary,
+		Timezone:        "UTC",
+	})
+	if err == nil {
+		t.Error("expected an error: ", err)
+	}
+	if err != nil {
+		if err != ErrTitleLength {
+			t.Error("expected title length error: ", err)
+		}
+	}
+
+	// Test invalid summary check
+	err = ValidateTalk(Talk{
+		TwitterUsername: ValidTwitterUsername,
+		Title:           ValidTitle,
+		Summary:         InvalidSummary,
+		Timezone:        "UTC",
+	})
+	if err == nil {
+		t.Error("expected an error: ", err)
+	}
+	if err != nil {
+		if err != ErrSummaryLength {
+			t.Error("expected summary length error: ", err)
+		}
+	}
+
+	// Test valid talk check
+	err = ValidateTalk(Talk{
+		TwitterUsername: ValidTwitterUsername,
+		Title:           ValidTitle,
+		Summary:         ValidSummary,
+		Timezone:        "UTC",
+	})
+	if err != nil {
+		t.Error("should have passed: ", err)
+	}
+}

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -32,7 +33,8 @@ func TestValidateTalk(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error: ", err)
 	}
-	if err != ErrTwitterUsernameDNE {
+	// if err != ErrTwitterUsernameDNE {
+	if !slices.Contains(err, ErrTwitterUsernameDNE) {
 		t.Error("expected twitter username error: ", err)
 	}
 
@@ -46,7 +48,8 @@ func TestValidateTalk(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error: ", err)
 	}
-	if err != ErrTitleLength {
+	// if err != ErrTitleLength {
+	if !slices.Contains(err, ErrTitleLength) {
 		t.Error("expected title length error: ", err)
 	}
 
@@ -60,7 +63,8 @@ func TestValidateTalk(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error: ", err)
 	}
-	if err != ErrSummaryLength {
+	// if err != ErrSummaryLength {
+	if !slices.Contains(err, ErrSummaryLength) {
 		t.Error("expected summary length error: ", err)
 	}
 

--- a/migrations/00001_add_talks_table.sql
+++ b/migrations/00001_add_talks_table.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE talks (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP(0) with time zone NOT NULL DEFAULT NOW(),
+    twitter_username TEXT NOT NULL,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    timezone TEXT NOT NULL
+);
+
+-- TODO: add indexes
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS talks;
+
+-- +goose StatementEnd

--- a/public/index.html
+++ b/public/index.html
@@ -1,3 +1,21 @@
-Join the communnity <a href="https://twitter.com/i/communities/1685641800449462272">here</a>
+{{ block "index" . }}
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title></title>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width-device-width, initial-scale=1">
+	</head>
+	<body>
+		Join the communnity <a href="https://twitter.com/i/communities/1685641800449462272">here</a>
 
-If you can read this, CI/CD now works too.
+		If you can read this, CI/CD now works too.
+		<br>
+		<br>
+		<div>
+			<a href="/submit-form/new">Submit a talk<a/>
+		</div>
+	</body>
+</html>
+{{end}}
+

--- a/public/new-talk.html
+++ b/public/new-talk.html
@@ -1,0 +1,47 @@
+{{ block "new-talk" . }}
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title></title>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width-device-width, initial-scale=1">
+	</head>
+	<body>
+		<nav>
+			<a href="/">Home</a>
+		</nav>
+		<h1>
+			Submit a new talk
+		</h1>
+		<form action="/submit-form" method="POST">
+			<label for="twitter-username">Twitter Username</label>
+			<input type="text" id="twitter-username" name="twitter-username" required/>
+
+			<br><br>
+
+			<label for="title">Title</label>
+			<input type="text" id="title" name="title" required/>
+
+			<br><br>
+
+			<label for="summary">Summary</label>
+			<textarea id="summary" name="summary"></textarea required>
+
+			<br><br>
+
+			<label for="time-zone">Time Zone</label>
+			<select id="time-zone" name="time-zone" required>
+				{{range .TimeZones}}
+	        <option value="{{ . }}">{{ . }}</option>
+				{{end}}
+	    </select>
+
+			<br><br>
+			<button type="submit">
+				Submit Talk
+			</button>
+		</form>
+	</body>
+</html>
+{{end}}
+

--- a/public/new-talk.html
+++ b/public/new-talk.html
@@ -13,6 +13,11 @@
 		<h1>
 			Submit a new talk
 		</h1>
+		{{if .Errors}}
+			{{range .Errors}}
+				{{.}}
+			{{end}}
+		{{end}}
 		<form action="/submit-form" method="POST">
 			<label for="twitter-username">Twitter Username</label>
 			<input type="text" id="twitter-username" name="twitter-username" required/>
@@ -25,7 +30,7 @@
 			<br><br>
 
 			<label for="summary">Summary</label>
-			<textarea id="summary" name="summary"></textarea required>
+			<textarea id="summary" name="summary" required></textarea>
 
 			<br><br>
 

--- a/public/new-talk.html
+++ b/public/new-talk.html
@@ -13,11 +13,15 @@
 		<h1>
 			Submit a new talk
 		</h1>
+		<ul>
 		{{if .Errors}}
 			{{range .Errors}}
-				{{.}}
+				<li>
+					{{.}}
+				</li>
 			{{end}}
 		{{end}}
+		</ul>
 		<form action="/submit-form" method="POST">
 			<label for="twitter-username">Twitter Username</label>
 			<input type="text" id="twitter-username" name="twitter-username" required/>

--- a/public/talk.html
+++ b/public/talk.html
@@ -1,0 +1,29 @@
+{{ block "talk-id" . }}
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title></title>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width-device-width, initial-scale=1">
+	</head>
+	<body>
+
+		<nav>
+			<a href="/">Home</a>
+			<a href="/submit-form/new">New talk</a>
+
+		</nav>
+		{{with .Talk}}
+		<h1>
+			Talk {{.ID}}
+		</h1>
+		<ul>
+			<li>{{.TwitterUsername}}</li>
+			<li>{{.Title}}</li>
+			<li>{{.Summary}}</li>
+			<li>{{.Timezone}}</li>
+		</ul>
+		{{end}}
+	</body>
+</html>
+{{end}}


### PR DESCRIPTION
I'd say this is still a work in progress, just wanted to make sure things are going on the right path. Since I was adding database functionality, I had to make some architecture decision, which I think everyone should be ok with before moving forward. 

I added:
- Docker DB instance
- SQL schema for talks table
- .env loading
- Data layer with services
- Handlers
  - Submit a talk proposal
  - Talk proposal form
  - View talk proposal by id
- Available timezones loading in the server
- Go template renderer 
- Air for hot reloading
- Makefile

I also didn't want to add new dependencies (like a router or a form parser) without getting an opinion from everybody else. I'd say Chi would be a good choice for a router. 

Other things missing or nice to haves
- Tests
- Check if twitter username exists (with API or web scraping?)
- Better error handling for user experience
  - Helper functions for consistency 
  - Dynamic error fields when submitting incorrect form
- Logger (slog, maybe?)
- Docker instance for web service
- Adminer docker instance for GUI interaction with the database
- Load .env variables for database commands in Makefiile